### PR TITLE
Copy edit

### DIFF
--- a/projects/Lesson-4/index.html
+++ b/projects/Lesson-4/index.html
@@ -27,7 +27,7 @@
         <p>
           <em>
             <strong>***Breaking News: AlphaGo has won the first two matches!***</strong> In this, the third in our series on the
-            epic Go matches being played between AlphaGo (Google’s Artificial Intelligence software) and Lee Se-Dol (Current
+            epic Go matches being played between AlphaGo (Google’s Artificial Intelligence software) and Lee Se-Dol (current
             Go World Champion), we look at the history of Humans vs. Machines, and the innovations that have led us to this
             incredible moment in time.</em>
         </p>
@@ -37,16 +37,16 @@
         </figure>
 
         <p>For as long as humans have built things, we’ve wrestled with the implications of what we’ve built. In many cases,
-          these philosophical and ethical wrestlings have made for great drama—think Frankenstein, or 2001: A Space Odyssey.
-          Often, the hypothetical scenarios we envision come remarkably close to true, and the discoveries we’ve made in
-          the fields of Artificial Intelligence and Machine Learning make clear that a “computer with a mind of its own”
+          these philosophical and ethical wrestlings have made for great drama &emdash; think Frankenstein, or 2001: A Space Odyssey.
+          Often, the hypothetical scenarios we envision come remarkably close to actual future outcomes, and the discoveries we’ve made in
+          the fields of Artificial Intelligence and Machine Learning make it clear that a “computer with a mind of its own”
           is
           <s>going to take over the world</s> not such a fantastic thing to imagine any longer.</p>
       </section>
       <section>
         <h2>The Triumph Of Deep Blue</h2>
 
-        <p>Perhaps this is why we are so captivated by human vs. machine competitions, because the idea of being overcome by
+        <p>Perhaps this is why we are so captivated by human vs. machine competitions &emdash; because the idea of being overcome by
           that which we’ve created speaks to something very deep within our collective consciousness. When IBM’s Deep Blue
           faced off against Garry Kasparov<sup>1</sup>, the event resulted in more than
           <a href="http://www-03.ibm.com/ibm/history/ibm100/us/en/icons/deepblue/">three billion impressions</a>
@@ -57,9 +57,9 @@
       <section>
         <h2>DeepMind’s AlphaGo</h2>
 
-        <p>Taking place right now, there is an event that, while not likely to scale the same media heights, may in fact have
+        <p>Taking place right now, there is an event that, while not likely to reach the same media heights, may in fact have
           far greater implications when it comes to the future of “intelligent” machines. On March 9, in Seoul, South Korea,
-          a computing system know as AlphoGo (built by researchers at DeepMind—a Google Artificial Intelligence lab) began
+          a computing system know as AlphaGo (built by researchers at DeepMind &emdash; a Google Artificial Intelligence lab) began
           <a href="http://venturebeat.com/2016/02/04/youtube-will-livestream-googles-ai-playing-go-superstar-lee-sedol-in-march/">a five-game match</a>
           against Lee Se-dol, one of the very best players in the world at the ancient game of Go.</p>
         <p>Why is this so significant?</p>
@@ -70,8 +70,8 @@
             its enormous search space and the difficulty of evaluating board positions and moves.</em>
         </p>
         <p>Put another way, winning at Go is a kind of Holy Grail for those who strive to create machines that can “think” on
-          their own, because success at this uniquely complex game seems to require something more than just skill, knowledge,
-          and experience. It requires intuition. Feel. Style. Characteristics we associate with humans, not with machines.</p>
+          their own, because success at this uniquely complex game seems to require something more than just skill, knowledge
+          and experience. It requires intuition. Feel. Style &emdash; characteristics we associate with humans, not with machines.</p>
         <hr>
         <aside>
           <sup>1</sup> Garry Kasparov is a Russian chess Grandmaster and former World Chess Champion

--- a/projects/Lesson-4/index.html
+++ b/projects/Lesson-4/index.html
@@ -66,8 +66,8 @@
         <p>Here is how the DeepMind team explained it in their paper
           <a href="http://airesearch.com/wp-content/uploads/2016/01/deepmind-mastering-go.pdf">Mastering the Game of Go with Deep Neural Networks and Tree Search</a>:</p>
         <p>
-          <em>The game of Go has long been viewed as the most challenging of classic games for artificial intelligence due to
-            its enormous search space and the difficulty of evaluating board positions and moves.</em>
+          <blockquote><em>The game of Go has long been viewed as the most challenging of classic games for artificial intelligence due to
+            its enormous search space and the difficulty of evaluating board positions and moves.</em></blockquote>
         </p>
         <p>Put another way, winning at Go is a kind of Holy Grail for those who strive to create machines that can “think” on
           their own, because success at this uniquely complex game seems to require something more than just skill, knowledge


### PR DESCRIPTION
Fixing up things in the original text that are blatantly wrong or egregiously painful for a lifelong copy-editing junkie.

Plus adding use of the `<blockquote>` tag that breaks the mockup but is obviously suited to where it's been implemented.